### PR TITLE
Make package.json contain minimal fields for install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "detect-installer",
   "version": "1.0.0",
+  "main": "lib/detect-installer.js",
   "dependencies": {
     "colors": "^1.4.0",
     "commander": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "detect-installer",
+  "version": "1.0.0",
   "dependencies": {
     "colors": "^1.4.0",
     "commander": "^10.0.1",


### PR DESCRIPTION
If we'd like to use `package.json` as a dependency, we first need to provide the `name`, `version`, and `main` fields to it.