### PR TITLE
Detect GUI installer before NPM and Yarn

### DIFF
--- a/lib/windows.js
+++ b/lib/windows.js
@@ -1,11 +1,18 @@
 const path = require("path");
 const { resolveCmd } = require("./shared");
-const Homebrew = require("./homebrew");
 const NPM = require("./npm");
 const Yarn = require("./yarn");
 const fs = require("fs-extra");
 
 async function detect(platform) {
+  // Maybe installed by GUI installer? Is ligo_uninstaller.exe present?
+  let ligoBinary = await resolveCmd(platform, "ligo");
+  let uninstallerExists = await fs.exists(
+    path.join(path.dirname(ligoBinary), "ligo_uninstaller.exe")
+  );
+  if (uninstallerExists) {
+    return "GUI Installer";
+  }
   let npmBinary = await resolveCmd(platform, "npm");
   if (npmBinary && (await NPM.installedByMe(platform, npmBinary)) === true) {
     return "npm";
@@ -13,15 +20,6 @@ async function detect(platform) {
   let yarnBinary = await resolveCmd(platform, "yarn");
   if (yarnBinary && (await Yarn.installedByMe(platform, yarnBinary)) === true) {
     return "yarn";
-  }
-  // Maybe installed by GUI installer? Is ligo_uninstaller.exe present?
-  let ligoBinary = await resolveCmd(platform, "ligo");
-  let uninstallerExists = await fs.exists(
-    path.join(path.dirname(ligoBinary), "ligo_uninstaller.exe")
-  );
-
-  if (uninstallerExists) {
-    return "GUI Installer";
   }
   return null;
 }


### PR DESCRIPTION
Problem: If there is more than one installation method in Windows, we should prefer the GUI installer.

Solution: Move the code that detects the GUI installer so it runs before the NPM and Yarn one.